### PR TITLE
Explicited int division on mask center calculation

### DIFF
--- a/ftdetect/masks.py
+++ b/ftdetect/masks.py
@@ -447,7 +447,7 @@ def usan(image, mode='Edge', radius=3.4, fptype=bool, t=25, gfrac=None,
         # Total number of pixels in mask
         ntot = len(maskout) - 1
         # Index and intensity of center pixel (i.e., the nucleus)
-        ctridx = ntot/2
+        ctridx = ntot//2
         nucleus = maskout[ctridx]
         # Delete data of center pixel in family of arrays with same dimension
         maskout = np.delete(maskout, ctridx)


### PR DESCRIPTION
Python 3 needs integer division to be called explicitly or else the result is returned as a floating point value. This resulted in maskout[ctridx] accessed with a floating point value and thus raising an exception in Python 3.
Since the integer division operator is the same, it can be fixed without breaking Python 2 compatibility.